### PR TITLE
Regix expression for username and password of students

### DIFF
--- a/backend/src/api/student/controllers/auth.js
+++ b/backend/src/api/student/controllers/auth.js
@@ -37,7 +37,7 @@ payload (user data) and a secret, and returned in the response to the client.
 // (e.g rajdeepn.ug20.cse@nitp.ac.in)
 
 
-const emailRegExp = /^[a-zA-Z0-9._]+\.ug(19|20|21)\.cse@nitp.ac.in$/;
+const emailRegExp = /^[a-zA-Z0-9._]+\.cse@nitp.ac.in$/;
 
 
 // Username should be a number of 7 digit


### PR DESCRIPTION
// email suffix ->    @nitp.ac.in 
// (e.g rajdeepn.ug20.cse@nitp.ac.in)


const emailRegExp = /^[a-zA-Z0-9._]+\.cse@nitp.ac.in$/;


// Username should be a number of 7 digit
// if current year is 2023, then users of year 2019, 2020, 2021 are allowed so first 2 digits of username should be either 19, 20 or 21 and last 4 digit can be any.
// so usernames can be of type 19____, 20____, 21____

const userNameRegExp = /^(19|20|21)\d{5}$/;